### PR TITLE
Fix react-react router 'exact' error

### DIFF
--- a/client/src/components/header/header.js
+++ b/client/src/components/header/header.js
@@ -7,9 +7,7 @@ const Header = () => (
   <header className="header ui inverted menu">
     <nav>
       <h1>
-        <Link to="/" exact>
-          My Pet
-        </Link>
+        <Link to="/">My Pet</Link>
       </h1>
       <ul>
         <li>


### PR DESCRIPTION
Removes 'exact' from root link in `header.js`. Fixes console error.