### PR TITLE
minor fixes

### DIFF
--- a/client/src/components/userform/formmenu.js
+++ b/client/src/components/userform/formmenu.js
@@ -4,17 +4,17 @@ const FormMenu = props => (
   <div className="ui pointing menu">
     <a
       onClick={props.toggler}
-      className={props.activeItem === "signup" ? "item active" : "item"}
-      role="button"
-    >
-      Signup
-    </a>
-    <a
-      onClick={props.toggler}
       className={props.activeItem === "login" ? "item active" : "item"}
       role="button"
     >
-      Login
+      Log in
+    </a>
+    <a
+      onClick={props.toggler}
+      className={props.activeItem === "signup" ? "item active" : "item"}
+      role="button"
+    >
+      Sign up
     </a>
   </div>
 );

--- a/client/src/components/userform/userform.js
+++ b/client/src/components/userform/userform.js
@@ -53,7 +53,9 @@ class UserForm extends Component {
     return (
       <div className="ui middle aligned center aligned grid custom-display-form">
         <div className="column">
-          <h2 className="ui black header">Log In</h2>
+          <h2 className="ui black header">
+            {this.state.activeItem === "signup" ? "Sign up" : "Log in"}
+          </h2>
           <FormMenu
             toggler={this.toggleForm}
             activeItem={this.state.activeItem}


### PR DESCRIPTION
Heading on the form changes accordingly to selection.
`Log in` tab is on the left, and `Sign up` on the right, matching the header. 

