### PR TITLE
Fix: Escape HTML entities, linting error

### DIFF
--- a/client/src/components/notfound/notfound.js
+++ b/client/src/components/notfound/notfound.js
@@ -7,7 +7,7 @@ import "./notfound.css";
 const NotFound = () => (
   <div className="notfound min-height">
     <h1 className="ui huge header">OOPS!</h1>
-    <h3 className="ui large header">I ate the page you're looking for.</h3>
+    <h3 className="ui large header">I ate the page you&apos;re looking for.</h3>
     <Link className="ui header blue" to="/">
       Are we going home now?
     </Link>


### PR DESCRIPTION
I forgot to lint before merging the last PR. 
This fixes the "escape-html-entities" error which is raised by es-lint.