### PR TITLE
Refactor/pet form

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,6 +15,7 @@
     "jsx-a11y/click-events-have-key-events": "warn",
     "react/jsx-filename-extension": [1, { "extensions": [".js", ".jsx"] }],
     "react/prop-types": "warn",
+    "react/no-did-mount-set-state": "off",
     "class-methods-use-this": "warn",
     "no-unused-expressions": ["error", { "allowTernary": true }]
   }

--- a/client/src/components/dashboard/dashboard.js
+++ b/client/src/components/dashboard/dashboard.js
@@ -49,7 +49,6 @@ class Dashboard extends Component {
         }))
       )
       .then(petList => {
-        console.log(petList);
         this.setState({
           petList
         });

--- a/client/src/components/petdetails/petdetails.js
+++ b/client/src/components/petdetails/petdetails.js
@@ -13,7 +13,12 @@ const PetDetails = props => {
   return (
     <div className="ui container">
       <div className="ui basic segment right aligned">
-        <Link to="/petform">
+        <Link
+          to={{
+            pathname: "/petform",
+            pet
+          }}
+        >
           <img
             src={pet.petAvatar}
             alt="Pet Avatar"

--- a/client/src/components/petform/petform.js
+++ b/client/src/components/petform/petform.js
@@ -2,6 +2,8 @@ import React, { Component } from "react";
 import PetInput from "./petinput";
 import petFormFields from "./petForm.json";
 import mapKeysToPetSchema from "../../utils/mapKeysToPetSchema";
+import mapPetSchemaToKeys from "../../utils/mapPetSchemaToKeys";
+import formatDate from "../../utils/formatDate";
 import postData from "../../utils/postData";
 
 // import "./petform.css";
@@ -24,9 +26,8 @@ class PetForm extends Component {
 
   componentDidMount() {
     if (this.props.location.pet) {
-      // const {pet} = this.props.location
-      // console.log(pet)
-      const pet = { Species: "orangutan" };
+      const pet = mapPetSchemaToKeys(this.props.location.pet);
+      pet["Born"] = formatDate(pet["Born"]); //format date from ISO to dd/mm/yyyy
       this.setState({
         pet: { ...this.state.pet, ...pet }
       });

--- a/client/src/components/petform/petform.js
+++ b/client/src/components/petform/petform.js
@@ -15,31 +15,42 @@ class PetForm extends Component {
     inputs.forEach(el => {
       initialState[el] = "";
     });
-    this.state = initialState;
+    this.state = { pet: initialState };
     this.handleCheckbox = this.handleCheckbox.bind(this);
     this.handleWriting = this.handleWriting.bind(this);
     this.handleDate = this.handleDate.bind(this);
     this.submit = this.submit.bind(this);
   }
 
+  componentDidMount() {
+    if (this.props.location.pet) {
+      // const {pet} = this.props.location
+      // console.log(pet)
+      const pet = { Species: "orangutan" };
+      this.setState({
+        pet: { ...this.state.pet, ...pet }
+      });
+    }
+  }
+
   handleWriting(e) {
     const { name } = e.target;
     this.setState({
-      [name]: e.target.value
+      pet: { ...this.state.pet, [name]: e.target.value }
     });
   }
 
   handleCheckbox(e) {
     const { name } = e.target;
-    const checked = Boolean(this.state[name]);
+    const checked = Boolean(this.state.pet[name]);
     this.setState({
-      [name]: !checked
+      pet: { ...this.state.pet, [name]: !checked }
     });
   }
 
   handleDate(d) {
     this.setState({
-      Born: d
+      pet: { ...this.state.pet, Born: d }
     });
   }
 
@@ -68,7 +79,7 @@ class PetForm extends Component {
       <PetInput
         key={el.name}
         {...el}
-        value={this.state[el.name]}
+        value={this.state.pet[el.name]}
         handleWriting={this.handleWriting}
         handleCheckbox={this.handleCheckbox}
         handleDate={this.handleDate}

--- a/client/src/components/petform/petform.js
+++ b/client/src/components/petform/petform.js
@@ -17,7 +17,7 @@ class PetForm extends Component {
     inputs.forEach(el => {
       initialState[el] = "";
     });
-    this.state = { pet: initialState };
+    this.state = { pet: initialState, mode: "create" };
     this.handleCheckbox = this.handleCheckbox.bind(this);
     this.handleWriting = this.handleWriting.bind(this);
     this.handleDate = this.handleDate.bind(this);
@@ -27,9 +27,10 @@ class PetForm extends Component {
   componentDidMount() {
     if (this.props.location.pet) {
       const pet = mapPetSchemaToKeys(this.props.location.pet);
-      pet["Born"] = formatDate(pet["Born"]); //format date from ISO to dd/mm/yyyy
+      pet.Born = formatDate(pet.Born); // format date from ISO to dd/mm/yyyy
       this.setState({
-        pet: { ...this.state.pet, ...pet }
+        pet: { ...this.state.pet, ...pet },
+        mode: "edit"
       });
     }
   }
@@ -61,11 +62,11 @@ class PetForm extends Component {
     const headers = new Headers();
     headers.append("Content-Type", "application/json");
 
-    const payload = mapKeysToPetSchema(this.state);
+    const payload = mapKeysToPetSchema(this.state.pet);
     payload.owner = this.props.user.id;
 
     const options = {
-      method: "POST",
+      method: this.state.mode === "create" ? "POST" : "PATCH",
       headers,
       body: JSON.stringify(payload)
     };
@@ -89,6 +90,11 @@ class PetForm extends Component {
     return (
       <div className="ui middle aligned center aligned grid custom-display-form">
         <div className="column">
+          <h2>
+            {this.state.mode === "create"
+              ? "You're now creating a new pet!"
+              : "You're now editing your pet!"}
+          </h2>
           <form onSubmit={this.submit} className="ui large form" id="petForm">
             <div className="ui stacked segment">{petInputs}</div>
             <input

--- a/client/src/utils/formatDate.js
+++ b/client/src/utils/formatDate.js
@@ -1,0 +1,22 @@
+/* eslint-disable */
+// https://stackoverflow.com/questions/19775488/javascript-how-to-convert-epoch-to-dd-mm-yyyy
+const formatDate = function(date) {
+  // function for reusability
+  date = new Date(date);
+  let d = date.getUTCDate().toString(), // getUTCDate() returns 1 - 31
+    m = (date.getUTCMonth() + 1).toString(), // getUTCMonth() returns 0 - 11
+    y = date.getUTCFullYear().toString(), // getUTCFullYear() returns a 4-digit year
+    formatted = "";
+  if (d.length === 1) {
+    // pad to two digits if needed
+    d = "0" + d;
+  }
+  if (m.length === 1) {
+    // pad to two digits if needed
+    m = "0" + m;
+  }
+  formatted = d + "/" + m + "/" + y; // concatenate for output
+  return formatted;
+};
+
+export default formatDate;

--- a/client/src/utils/mapKeysToPetSchema.js
+++ b/client/src/utils/mapKeysToPetSchema.js
@@ -1,6 +1,7 @@
 /* eslint-disable */
 const mapKeysToPetSchema = object => {
   const schemaNames = {
+    id: "id",
     Name: "petName",
     Avatar: "petAvatar",
     Species: "species",

--- a/client/src/utils/mapPetSchemaToKeys.js
+++ b/client/src/utils/mapPetSchemaToKeys.js
@@ -1,0 +1,22 @@
+/* eslint-disable */
+const mapPetSchemaToKeys = object => {
+  const schemaNames = {
+    id: "id",
+    petName: "Name",
+    petAvatar: "Avatar",
+    species: "Species",
+    breed: "Breed",
+    dob: "Born",
+    description: "Description",
+    sex: "Sex",
+    neutered: "Neutered"
+  };
+  const newObj = {};
+
+  for (const key of Object.keys(object)) {
+    newObj[schemaNames[key]] = object[key];
+  }
+  return newObj;
+};
+
+export default mapPetSchemaToKeys;


### PR DESCRIPTION
`PetForm `will now accept props to prepopulate fields while editing.
Helper functions are created to parse date in isoformat and map keys from those received from DB to those used in `PetForm `state.

When editing a pet PATCH method will be used in fetch instead of POST. 
A `<h2>` header is added to indicate that but it should be probably changed to something else.
